### PR TITLE
Allow using type parameters in base types in more scenarios

### DIFF
--- a/GenericsAnalyzer/GenericsAnalyzer.Test/BaseAnalyzerTests.cs
+++ b/GenericsAnalyzer/GenericsAnalyzer.Test/BaseAnalyzerTests.cs
@@ -1,6 +1,7 @@
 ﻿using Gu.Roslyn.Asserts;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace GenericsAnalyzer.Test
 {
@@ -19,6 +20,13 @@ namespace GenericsAnalyzer.Test
         protected void AssertDiagnostics(string testCode)
         {
             RoslynAssert.Diagnostics(GetNewDiagnosticAnalyzerInstance(), ExpectedDiagnostic, testCode);
+        }
+
+        // No diagnostics expected to show up
+        [TestMethod]
+        public void EmptyCode()
+        {
+            ValidateCode(@"");
         }
     }
 }

--- a/GenericsAnalyzer/GenericsAnalyzer.Test/PermittedTypeArguments/GA0001_Tests.cs
+++ b/GenericsAnalyzer/GenericsAnalyzer.Test/PermittedTypeArguments/GA0001_Tests.cs
@@ -11,14 +11,6 @@ namespace GenericsAnalyzer.Test.PermittedTypeArguments
 
         protected override DiagnosticAnalyzer GetNewDiagnosticAnalyzerInstance() => new PermittedTypeArgumentAnalyzer();
 
-        // No diagnostics expected to show up
-        [TestMethod]
-        public void EmptyCode()
-        {
-            ValidateCode(@"");
-        }
-
-        // Usage of type arguments in inheritance
         [TestMethod]
         public void IntermediateGenericTypeUsage()
         {
@@ -35,7 +27,97 @@ class B<T> : A<T>
             ValidateCode(testCode);
         }
 
-        // Usage of prohibited type arguments in inheritance
+        [TestMethod]
+        public void IntermediateSubsetGenericTypeUsage()
+        {
+            var testCode =
+@"
+using GenericsAnalyzer.Core;
+
+class Program
+{
+    static void Main()
+    {
+        new A<int>();
+        new B<int>();
+        new A<↓A>();
+        new B<↓A>();
+        new A<B>();
+        new B<↓B>();
+    }
+}
+
+class A
+<
+    [ProhibitedBaseTypes(typeof(IA))]
+    T
+>
+{
+}
+class B
+<
+    [ProhibitedBaseTypes(typeof(IB))]
+    T
+> : A<T>
+{
+}
+class C
+<
+    [ProhibitedBaseTypes(typeof(IC))]
+    T
+> : A<↓T>
+{
+}
+
+interface IA : IB { }
+interface IB { }
+interface IC : IA { }
+
+class A : IA { }
+class B : IB { }
+";
+
+            AssertDiagnostics(testCode);
+        }
+
+        [TestMethod]
+        public void IntermediateExplicitlyPermittedGenericTypeUsage()
+        {
+            var testCode =
+@"
+using GenericsAnalyzer.Core;
+
+class Program
+{
+    static void Main()
+    {
+        new A<int>();
+        new B<int>();
+        new A<↓string>();
+        new B<↓string>();
+    }
+}
+
+class A
+<
+    [PermittedTypes(typeof(int), typeof(uint))]
+    [OnlyPermitSpecifiedTypes]
+    T
+>
+{
+}
+class B
+<
+    [InheritBaseTypeUsageConstraints]
+    T
+> : A<T>
+{
+}
+";
+
+            AssertDiagnostics(testCode);
+        }
+
         [TestMethod]
         public void IntermediateProhibitedGenericTypeUsage()
         {
@@ -74,7 +156,6 @@ class B
             AssertDiagnostics(testCode);
         }
 
-        // Usage of prohibited type arguments in inheritance
         [TestMethod]
         public void IntermediateTwoClassProhibitedGenericTypeUsage()
         {
@@ -120,7 +201,6 @@ class C
             AssertDiagnostics(testCode);
         }
 
-        // Usage of prohibited type arguments for class
         [TestMethod]
         public void GenericClassTestCode()
         {
@@ -154,7 +234,6 @@ class Generic
             AssertDiagnostics(testCode);
         }
 
-        // Usage of prohibited type arguments for function
         [TestMethod]
         public void GenericFunctionTestCode()
         {
@@ -189,7 +268,6 @@ class Program
             AssertDiagnostics(testCode);
         }
 
-        // Usage of prohibited type arguments for class with OnlyPermitSpecifiedTypesAttribute
         [TestMethod]
         public void OnlyPermitSpecifiedTypesTestCode()
         {

--- a/GenericsAnalyzer/GenericsAnalyzer/PermittedTypeArgumentAnalyzer.cs
+++ b/GenericsAnalyzer/GenericsAnalyzer/PermittedTypeArgumentAnalyzer.cs
@@ -148,10 +148,10 @@ namespace GenericsAnalyzer
                             // Recursively analyze base type definitions
                             AnalyzeGenericNameDefinition(context, inheritedType);
 
-                            var typeArguments = inheritedType.TypeArguments;
-                            for (int k = 0; k < typeArguments.Length; k++)
-                                if (typeArguments[k].Name == parameter.Name)
-                                    system.InheritFrom(genericNames[inheritedType][k]);
+                            var inheritedTypeParameters = inheritedType.TypeParameters;
+                            for (int k = 0; k < inheritedTypeParameters.Length; k++)
+                                if (inheritedTypeParameters[k].Name == parameter.Name)
+                                    system.InheritFrom(inheritedTypeParameters[k], genericNames[inheritedType][k]);
                         }
                         continue;
                     }
@@ -191,7 +191,32 @@ namespace GenericsAnalyzer
 
                 var system = constraints[i];
                 var argumentType = semanticModel.GetTypeInfo(argument).Type;
-                if (!system.IsPermitted(argumentType))
+
+                bool isPermitted = false;
+                if (argumentType is ITypeParameterSymbol declaredTypeParameter)
+                {
+                    var declaringElement = declaredTypeParameter.DeclaringMethod;
+                    ImmutableArray<ITypeParameterSymbol> declaringElementTypeParameters;
+                    if (declaringElement is null)
+                        declaringElementTypeParameters = declaredTypeParameter.DeclaringType.TypeParameters;
+                    else
+                        declaringElementTypeParameters = declaringElement.TypeParameters;
+
+                    for (int j = 0; j < declaringElementTypeParameters.Length; j++)
+                    {
+                        if (declaringElementTypeParameters[j].Name == declaredTypeParameter.Name)
+                        {
+                            isPermitted = system.IsPermitted(declaredTypeParameter, j, genericNames);
+                            break;
+                        }
+                    }
+                }
+                else
+                {
+                    isPermitted = system.IsPermitted(argumentType);
+                }
+
+                if (!isPermitted)
                 {
                     var diagnostic = Diagnostic.Create(GA0001_Rule, argument.GetLocation(), originalDefinition.ToDisplayString(), argumentType.ToDisplayString());
                     context.ReportDiagnostic(diagnostic);


### PR DESCRIPTION
Fixes a broad range of issues that would involve slightly more complex constraint rules than the actually tested