### PR TITLE
Add more tests for GA0005

### DIFF
--- a/GenericsAnalyzer/GenericsAnalyzer.Test/PermittedTypeArguments/GA0005_Tests.cs
+++ b/GenericsAnalyzer/GenericsAnalyzer.Test/PermittedTypeArguments/GA0005_Tests.cs
@@ -26,5 +26,122 @@ class C
 
             AssertDiagnosticsWithUsings(testCode);
         }
+
+        [TestMethod]
+        public void StructConstraint()
+        {
+            var testCode =
+@"
+class C { }
+struct S { }
+struct Managed
+{
+    List<int> list;
+}
+
+class Generic
+<
+    [PermittedTypes(↓typeof(string))]
+    [ProhibitedTypes(↓typeof(IEnumerable<int>))]
+    [ProhibitedBaseTypes(typeof(IEnumerable<uint>))]
+    [ProhibitedTypes(typeof(int))]
+    [ProhibitedTypes(typeof(Managed))]
+    [PermittedBaseTypes(↓typeof(C))]
+    T
+>
+    where T : struct
+{
+}
+";
+
+            AssertDiagnosticsWithUsings(testCode);
+        }
+        [TestMethod]
+        public void UnmanagedConstraint()
+        {
+            var testCode =
+@"
+class C { }
+struct S { }
+struct Managed
+{
+    List<int> list;
+}
+
+class Generic
+<
+    [PermittedTypes(↓typeof(string))]
+    [ProhibitedTypes(↓typeof(IEnumerable<int>))]
+    [ProhibitedBaseTypes(typeof(IEnumerable<uint>))]
+    [ProhibitedTypes(typeof(int))]
+    [ProhibitedTypes(↓typeof(Managed))]
+    [PermittedBaseTypes(↓typeof(C))]
+    T
+>
+    where T : unmanaged
+{
+}
+";
+
+            AssertDiagnosticsWithUsings(testCode);
+        }
+        [TestMethod]
+        public void ClassConstraint()
+        {
+            var testCode =
+@"
+class C { }
+struct S { }
+struct Managed
+{
+    List<int> list;
+}
+
+class Generic
+<
+    [PermittedTypes(typeof(string))]
+    [ProhibitedTypes(typeof(IEnumerable<int>))]
+    [ProhibitedBaseTypes(typeof(IEnumerable<uint>))]
+    [ProhibitedTypes(↓typeof(int))]
+    [ProhibitedTypes(↓typeof(Managed))]
+    [PermittedBaseTypes(typeof(C))]
+    T
+>
+    where T : class
+{
+}
+";
+
+            AssertDiagnosticsWithUsings(testCode);
+        }
+        [TestMethod]
+        public void NewConstraint()
+        {
+            var testCode =
+@"
+class C { }
+struct S { }
+struct Managed
+{
+    List<int> list;
+}
+
+class Generic
+<
+    [PermittedTypes(↓typeof(string))]
+    [ProhibitedTypes(↓typeof(IEnumerable<int>))]
+    [ProhibitedBaseTypes(typeof(IEnumerable<uint>))]
+    [ProhibitedTypes(typeof(int))]
+    [ProhibitedTypes(typeof(Managed))]
+    [PermittedBaseTypes(typeof(C))]
+    T
+>
+    where T : new()
+{
+}
+";
+
+            AssertDiagnosticsWithUsings(testCode);
+        }
     }
 }


### PR DESCRIPTION
Although the behavior has always been correct, it was never properly tested. Just a pat on the head.